### PR TITLE
Add support for GHC 8.8.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Support ghc-8.6, but drop support for ghc<7.10
 * Fix default formatter for strings
+* Via x-revision 1 on September 2019: Support ghc-8.8
 
 ## 0.1.0.1  -- April 2018
 

--- a/data-tree-print.cabal
+++ b/data-tree-print.cabal
@@ -36,7 +36,7 @@ source-repository head {
 library
   exposed-modules:     DataTreePrint
   build-depends:
-    { base >=4.8 && <4.13
+    { base >=4.8 && <4.14
     , pretty >=1.1 && <1.2
     , syb >=0.6 && <0.8
     }

--- a/iridium.yaml
+++ b/iridium.yaml
@@ -15,7 +15,9 @@ checks:
         version: "8.4.3"
       - compiler: "ghc"
         version: "8.6.1"
-    compilers-help: |
+      - compiler: "ghc"
+        version: "8.8.1"
+     compilers-help: |
       for this to work, cabal will need the paths to the actual
       compilers to be configured; see the note about the user-global
       config above.


### PR DESCRIPTION
Bumping the version of base such that data-tree-print will build with GHC 8.8.1.

This is so that brittnay (http://hackage.haskell.org/package/brittany) can be built with GHC 8.8.1.

I'm happy to make changes to the pull request if required.