### PR TITLE
Allow base < 4.17 and ghc <= 9.2.1

### DIFF
--- a/data-tree-print.cabal
+++ b/data-tree-print.cabal
@@ -36,7 +36,7 @@ source-repository head {
 library
   exposed-modules:     DataTreePrint
   build-depends:
-    { base >=4.8 && <4.14
+    { base >=4.8 && <4.17
     , pretty >=1.1 && <1.2
     , syb >=0.6 && <0.8
     }


### PR DESCRIPTION
* Superseeds #2
* It would need a hackage release/revision
* Needed to make brittany haskell-language-server plugin for ghc-9.0.1 and hackage

//cc @lspitzner thanks in advance!